### PR TITLE
Ability to pass custom options to handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+Please include notes on all updates and changes here.
+
+
+# 0.0.2
+
+Ability to pass a custom `Hash` to the handlers, e.g. to pass OAuth provider URL
+or any other configuration required by handlers.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Then instanciate an `NsqSubscriber` specifying the NSQLookupd, topic and channel
 subscriber = NsqSubscriber.new(
   lookupd: "http://127.0.0.1:4161",
   topic: "example_topic",
-  channel: "test_app"
+  channel: "test_app",
+  handler_options: {"oauth_provider": "http://www.example.com"}
 )
 subscriber["test_this"] = ExampleHandler
 subscriber.listen
@@ -60,6 +61,9 @@ is in the following format it will trigger `ExampleHandler#call`.
   }
 }
 ```
+
+The `:handler_options` key will be passed to the handler when a relevant message
+will be received.
 
 ## Development
 

--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -12,6 +12,7 @@ class NsqSubscriber
     @channel = args.fetch(:channel)
 
     @logger = args.fetch(:logger) { Logger.new(STDOUT) }
+    @handler_options = args.fetch(:handler_options, {})
 
     @handlers = Hash.new(NoHandlerWarningHandler)
   end
@@ -59,7 +60,8 @@ class NsqSubscriber
     def process_message(message)
       json_message = JSON.parse(message.message)
       message_type = json_message["meta"]["event"]
-      handler = @handlers[message_type].new(json_message, logger: @logger)
+      handler_options = {logger: @logger}.merge(@handler_options)
+      handler = @handlers[message_type].new(json_message, handler_options)
       handler.call
     end
 

--- a/lib/nsq_subscriber/version.rb
+++ b/lib/nsq_subscriber/version.rb
@@ -1,3 +1,3 @@
 class NsqSubscriber
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This is very useful. For example your application's handlers could need the
URL of your OAuth provider and it could come from your application settings.

Now you can pass these options to the NsqSubscriber and they'll be passed over
to the handlers when a message arrives:

```ruby
subscriber = NsqSubscriber.new(
  lookupd: NSQ_LOOKUPD,
  topic: NSQ_TOPIC,
  channel: NSQ_CHANNEL,
  handler_options: {
    oauth_provider: OAUTH_PROVIDER,
    other_custom_stuff: "yes plese"
  }
)
```