### PR TITLE
Read from the NSQ queue less frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Please include notes on all updates and changes here.
 
 
+# 0.0.3
+
+Read NSQ messages less frequently.
+
+
 # 0.0.2
 
 Ability to pass a custom `Hash` to the handlers, e.g. to pass OAuth provider URL

--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -12,6 +12,7 @@ class NsqSubscriber
     @channel = args.fetch(:channel)
 
     @logger = args.fetch(:logger) { Logger.new(STDOUT) }
+    @sleep_secs = args.fetch(:sleep_secs, 1)
     @handler_options = args.fetch(:handler_options, {})
 
     @handlers = Hash.new(NoHandlerWarningHandler)
@@ -24,6 +25,7 @@ class NsqSubscriber
   def listen
     while true do
       read_messages
+      sleep(@sleep_secs)
     end
   end
 

--- a/lib/nsq_subscriber/version.rb
+++ b/lib/nsq_subscriber/version.rb
@@ -1,3 +1,3 @@
 class NsqSubscriber
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
By default we wait 1 second from a read to the other (but pass the `:sleep_secs`
option if you need to change it)