### PR TITLE
[WIP] Fix for services stopping receiving NSQ messages

### DIFF
--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -7,7 +7,7 @@ require_relative "nsq_subscriber/no_handler_warning_handler"
 class NsqSubscriber
 
   DEFAULT_SLEEP_SECS = 30
-  MAX_EMPTY_QUEUE_ATTEMPTS = 10
+  MAX_EMPTY_QUEUE_ATTEMPTS = 20
 
   def initialize(args)
     @lookupd = args.fetch(:lookupd)

--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -12,7 +12,7 @@ class NsqSubscriber
     @channel = args.fetch(:channel)
     @max_in_flight = args.fetch(:max_in_flight, 25)
     @logger = args.fetch(:logger) { Logger.new(STDOUT) }
-    @sleep_secs = args.fetch(:sleep_secs, 1)
+    @sleep_secs = args.fetch(:sleep_secs, 15)
     @handler_options = args.fetch(:handler_options, {})
 
     @handlers = Hash.new(NoHandlerWarningHandler)

--- a/lib/nsq_subscriber/version.rb
+++ b/lib/nsq_subscriber/version.rb
@@ -1,3 +1,3 @@
 class NsqSubscriber
-  VERSION = "0.0.4"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
We noticed that for some obscure reason the Ruby services processing NSQ messages sometimes stop receiving them. Once the service is restarted, it start to received the NSQ messages again.

This happened after a glitch on the NSQD nodes, we can only guess it's something related with the connection kept alive for too long.

### How to reproduce

I couldn't reproduce this locally. I tried to kill the nsqd node and/or nsqlookupd node but once they were back online the Ruby service restarted to get the NSQ messages as expected.

I also tried to start two

### Speculative solution

The way we listen for NSQ messages here is simple, instantiate a `Krakow::Consumer` and then we periodically (every 1 second!!) check its queue . The same `Krakow::Consumer` ruby object instance is used from the start to the end.

With these changes we count the number of times the queue had no [WIP.....]




Ticket: https://quillcontent.atlassian.net/browse/PROJ-191