### PR TITLE
Requeue messages on failure. Also improves backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Please include notes on all updates and changes here.
 
+# 0.0.5
+
+* Messages are re-queued/re-tried on exception
+* Adds `max_attempts` config which determines the number of times a message
+  will be re-queue on fail. Default is 15
+* Adds `backoff_interval` config is used to calculate for how long the consumer
+  will backoff when failures occur (failures * backoff_interval seconds).
+  Default is 120 seconds
+
 # 0.0.4
 
 **Custom Krakow build** while we await a fix/alternative for [this PR](https://github.com/chrisroberts/krakow/pull/36).

--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -10,7 +10,12 @@ class NsqSubscriber
     @lookupd = args.fetch(:lookupd)
     @topic   = args.fetch(:topic)
     @channel = args.fetch(:channel)
+    # Maximum number of messages to allow in flight (concurrency knob)
     @max_in_flight = args.fetch(:max_in_flight, 25)
+    # Maximum number of times this consumer will attempt to process a message before giving up
+    @max_attempts = args.fetch(:max_attempts, 15)
+    @backoff_interval = args.fetch(:backoff_interval, 120)
+
     @logger = args.fetch(:logger) { Logger.new(STDOUT) }
     @sleep_secs = args.fetch(:sleep_secs, 1)
     @handler_options = args.fetch(:handler_options, {})
@@ -38,13 +43,17 @@ class NsqSubscriber
           message = subscriber.queue.pop
           @logger.info("NSQ message received = #{message.message}")
 
-          process_message(message)
+          if message.attempts > @max_attempts
+            @logger.info("msg #{message.message_id} attempted #{message.attempts} times, giving up")
+          else
+            process_message(message)
+          end
+          subscriber.confirm(message.message_id)
         rescue Exception => e
           backtrace = e.backtrace.join("\n")
           @logger.error("Error while processing message: #{e}")
           @logger.error("Backtrace: #{backtrace}")
-        ensure
-          subscriber.confirm(message.message_id)
+          subscriber.requeue(message.message_id)
         end
       end
     end
@@ -56,7 +65,8 @@ class NsqSubscriber
           nsqlookupd: @lookupd,
           topic: @topic,
           channel: @channel,
-          max_in_flight: @max_in_flight
+          max_in_flight: @max_in_flight,
+          backoff_interval: @backoff_interval,
         )
       end
     end

--- a/lib/nsq_subscriber.rb
+++ b/lib/nsq_subscriber.rb
@@ -44,7 +44,7 @@ class NsqSubscriber
           @logger.info("NSQ message received = #{message.message}")
 
           if message.attempts > @max_attempts
-            @logger.info("msg #{message.message_id} attempted #{message.attempts} times, giving up")
+            @logger.warn("msg #{message.message_id} attempted #{message.attempts} times, giving up")
           else
             process_message(message)
           end

--- a/lib/nsq_subscriber/version.rb
+++ b/lib/nsq_subscriber/version.rb
@@ -1,3 +1,3 @@
 class NsqSubscriber
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
The previous behaviour was to always confirm NSQ messages even when they failed
to be processed successfully.

Messages are requeued when an exception is raised. Messages are re-queue if the
number of attempts is under `:max_attempts` (15 by default). Discarded otherwise.

We also set the `:backoff_interval` (120s by default). This means the consumer
will slowdown when failures occur giving things the time to recover.

As far as I can tell from [its code Krakow](https://github.com/chrisroberts/krakow/blob/7d951699c9fc586b536b94b84e478925d9f6ca40/lib/krakow/distribution.rb#L203) is using a linear backoff strategy [1].
It keeps track of the number of failures and it will use this number to determine
the backoff interval:

```ruby
registry_info[:backoff_until] = Time.now.to_i + (registry_info[:failures] * backoff_interval)
```