### PR TITLE
v0.1.0 Replaces krakow with nsq-ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Please include notes on all updates and changes here.
 
+# 0.1.0
+
+* Using nsq-ruby gem to subscribe to nsq instead of Krakow
+* Adds `max_backoff` config which determines the max time (in minutes) to backoff on message failure. Default is 8h. An exponential backoff strategy is used.
+* Removed `backoff_interval` config
+
 # 0.0.5
 
 * Messages are re-queued/re-tried on exception
@@ -15,7 +21,7 @@ Please include notes on all updates and changes here.
 
 **Custom Krakow build** while we await a fix/alternative for [this PR](https://github.com/chrisroberts/krakow/pull/36).
 
-Adds a `max_in_flight` configuration option to specificy how many messages to take form the queue. Otherwise we read one message, then wait 1 second, this can quickly get delayed when the team is all testing at once. 
+Adds a `max_in_flight` configuration option to specificy how many messages to take form the queue. Otherwise we read one message, then wait 1 second, this can quickly get delayed when the team is all testing at once.
 
 # 0.0.3
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ is in the following format it will trigger `ExampleHandler#call`.
 The `:handler_options` key will be passed to the handler when a relevant message
 will be received.
 
+## Running the tests
+
+To run the tests:
+
+```bash
+$ bundle exec rspec
+```
+
+NOTE: nsqd and nsqlookupd will need to be running locally. Follow the instructions on NSQ documentation: http://nsq.io/overview/quick_start.html
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/nsq_subscriber/version.rb
+++ b/lib/nsq_subscriber/version.rb
@@ -1,3 +1,3 @@
 class NsqSubscriber
-  VERSION = "0.0.5"
+  VERSION = "0.1.0"
 end

--- a/nsq_subscriber.gemspec
+++ b/nsq_subscriber.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency "krakow", "~> 0.4.2"
+  spec.add_dependency "nsq-ruby", "~> 1.7.0"
+
+  spec.add_development_dependency "rspec", "~> 3.4.0"
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "byebug", "~> 4.0.5"

--- a/spec/nsq_subscriber_spec.rb
+++ b/spec/nsq_subscriber_spec.rb
@@ -1,11 +1,55 @@
-require 'spec_helper'
+require "spec_helper"
+require "nsq"
+
+LOOKUPD = "http://127.0.0.1:4161"
+NSQD = "127.0.0.1:4150"
+TOPIC = "test_topic"
+CHANNEL = "tests"
+MSG_TYPE = "msg_type"
+
+class TestHandler
+  def initialize(json_message, opts)
+    @message = json_message
+    @logger = opts.fetch(:logger)
+  end
+
+  def call
+    @logger.info "TestHandler#call"
+  end
+end
 
 describe NsqSubscriber do
-  it 'has a version number' do
-    expect(NsqSubscriber::VERSION).not_to be nil
+
+  let(:subscriber) do
+    described_class.new(lookupd: LOOKUPD, topic: TOPIC, channel: CHANNEL)
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  let(:message) do
+    {
+      "meta": {
+        "event": MSG_TYPE
+      }
+    }
   end
+
+  let(:publish_msg) do
+    begin
+      Nsq::Producer.new(nsqd: NSQD, topic: TOPIC).write(message.to_json)
+    rescue Errno::ECONNREFUSED => e
+      throw "Failed to publish NSQ message. Is nsqd running on #{NSQD}? #{e.message}"
+    end
+  end
+
+  before do
+    publish_msg
+    subscriber[MSG_TYPE] = TestHandler
+  end
+
+  it "calls #call on the handler" do
+    expect_any_instance_of(TestHandler).to receive(:call)
+
+    thread = Thread.new { subscriber.listen }
+    sleep(4)
+  end
+
 end


### PR DESCRIPTION
We hope this gem should handle reconnection with nsqd nodes better.
Currently when the nsqd nodes goes down/are restarted krakow stop receiving
NSQ messages